### PR TITLE
Fix issues with window insets on Android 35

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.kenkeremath.mtgcounter"
         minSdkVersion 23
         targetSdkVersion 35
-        versionCode 27
-        versionName "3.4.1"
+        versionCode 28
+        versionName "3.4.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/res/layout/activity_theme.xml
+++ b/app/src/main/res/layout/activity_theme.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"

--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -4,7 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="bottom"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"

--- a/app/src/main/res/layout/fragment_manage_counters.xml
+++ b/app/src/main/res/layout/fragment_manage_counters.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"

--- a/app/src/main/res/layout/fragment_manage_profiles.xml
+++ b/app/src/main/res/layout/fragment_manage_profiles.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"

--- a/app/src/main/res/layout/fragment_setup.xml
+++ b/app/src/main/res/layout/fragment_setup.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"

--- a/app/src/main/res/layout/fragment_tabletop_setup.xml
+++ b/app/src/main/res/layout/fragment_tabletop_setup.xml
@@ -4,7 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/scBackgroundColor"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"


### PR DESCRIPTION
1. Addresses an issue with window insets overlapping screen content on setup screens in API 35
2. Bumps version code for new internal test release (3.4.2)

| Before | After |
| ----- | ----- |
| ![screenshot_2025-07-02_12-49-52](https://github.com/user-attachments/assets/22a755da-d1ad-4ba0-bfbd-4e26fa190ce0) | ![screenshot_2025-07-02_12-49-36](https://github.com/user-attachments/assets/533714d4-56ad-4634-917c-4c0a85450a06) |

