### PR TITLE
Fix edit profile scrolling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.kenkeremath.mtgcounter"
         minSdkVersion 23
         targetSdkVersion 35
-        versionCode 28
-        versionName "3.4.2"
+        versionCode 29
+        versionName "3.4.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/kenkeremath/mtgcounter/ui/settings/counters/manage/ManageCountersRecyclerAdapter.kt
+++ b/app/src/main/java/com/kenkeremath/mtgcounter/ui/settings/counters/manage/ManageCountersRecyclerAdapter.kt
@@ -120,4 +120,8 @@ class CreateCounterViewHolder(
             onCounterClickedListener.onCounterCreateClicked()
         }
     }
+
+    fun bind() {
+        //no op
+    }
 }

--- a/app/src/main/java/com/kenkeremath/mtgcounter/ui/settings/profiles/edit/EditProfileRecyclerAdapter.kt
+++ b/app/src/main/java/com/kenkeremath/mtgcounter/ui/settings/profiles/edit/EditProfileRecyclerAdapter.kt
@@ -1,86 +1,135 @@
 package com.kenkeremath.mtgcounter.ui.settings.profiles.edit
 
-import android.annotation.SuppressLint
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
 import android.widget.CompoundButton
+import android.widget.EditText
+import android.widget.ImageView
+import androidx.core.graphics.drawable.toDrawable
 import androidx.recyclerview.widget.RecyclerView
 import com.kenkeremath.mtgcounter.R
+import com.kenkeremath.mtgcounter.model.counter.CounterTemplateModel
 import com.kenkeremath.mtgcounter.ui.settings.counters.manage.CreateCounterViewHolder
 import com.kenkeremath.mtgcounter.ui.settings.counters.manage.OnManageCounterClickedListener
+import com.kenkeremath.mtgcounter.ui.setup.theme.ScThemeUtils
+import com.kenkeremath.mtgcounter.ui.setup.theme.previewBackgroundColor
 import com.kenkeremath.mtgcounter.view.counter.CounterIconView
+import com.kenkeremath.mtgcounter.view.counter.LifeCounterView
 import com.kenkeremath.mtgcounter.view.counter.edit.CounterSelectionUiModel
 
-class EditProfileRecyclerAdapter(
+class EditProfileContentAdapter(
     private val editProfileCounterClickedListener: OnEditProfileCounterClickedListener,
-    private val onManageCounterClickedListener: OnManageCounterClickedListener
-) :
-    RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-
-    companion object {
-        private const val TYPE_CREATE = 0
-        private const val TYPE_COUNTER = 1
-        private const val ID_CREATE = -1L
-    }
-
+    private val onManageCounterClickedListener: OnManageCounterClickedListener,
+    private val onNameChangedListener: (String) -> Unit,
+    private val onEditLifeCounterClickListener: () -> Unit
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     init {
         setHasStableIds(true)
     }
 
-    private val counters: MutableList<CounterSelectionUiModel> = mutableListOf()
+    companion object {
+        private const val TYPE_NAME = 0
+        private const val TYPE_LIFE_COUNTER = 1
+        private const val TYPE_COUNTERS_HEADER = 2
+        private const val TYPE_CREATE_COUNTER = 3
+        private const val TYPE_COUNTER = 4
+    }
 
-    @SuppressLint("NotifyDataSetChanged")
-    fun setCounters(counters: List<CounterSelectionUiModel>) {
-        this.counters.clear()
-        this.counters.addAll(counters)
+    private val items = mutableListOf<EditProfileItem>()
+
+    fun setItems(
+        profileName: String,
+        isNameChangeEnabled: Boolean,
+        lifeCounter: CounterTemplateModel?,
+        counterSelections: List<CounterSelectionUiModel>
+    ) {
+        items.clear()
+        
+        // Add name section
+        items.add(EditProfileItem.Name(profileName, isNameChangeEnabled))
+        
+        // Add life counter section
+        items.add(EditProfileItem.LifeCounter(lifeCounter))
+        
+        // Add counters header
+        items.add(EditProfileItem.CountersHeader)
+        
+        // Add create counter button
+        items.add(EditProfileItem.CreateCounter)
+        
+        // Add counter items
+        counterSelections.forEach { counter ->
+            items.add(EditProfileItem.Counter(counter))
+        }
+        
         notifyDataSetChanged()
     }
 
-    override fun onCreateViewHolder(
-        parent: ViewGroup,
-        viewType: Int
-    ): RecyclerView.ViewHolder {
-        return if (viewType == TYPE_CREATE) {
-            CreateCounterViewHolder(
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            TYPE_NAME -> NameViewHolder(
+                LayoutInflater.from(parent.context)
+                    .inflate(R.layout.item_edit_profile_name, parent, false),
+                onNameChangedListener
+            )
+            TYPE_LIFE_COUNTER -> LifeCounterViewHolder(
+                LayoutInflater.from(parent.context)
+                    .inflate(R.layout.item_edit_profile_life_counter, parent, false),
+                onEditLifeCounterClickListener
+            )
+            TYPE_COUNTERS_HEADER -> CountersHeaderViewHolder(
+                LayoutInflater.from(parent.context)
+                    .inflate(R.layout.item_edit_profile_counters_header, parent, false)
+            )
+            TYPE_CREATE_COUNTER -> CreateCounterViewHolder(
                 LayoutInflater.from(parent.context)
                     .inflate(R.layout.item_manage_counter_create, parent, false),
                 onManageCounterClickedListener
             )
-        } else {
-            EditProfileCounterViewHolder(
+            TYPE_COUNTER -> EditProfileCounterViewHolder(
                 LayoutInflater.from(parent.context)
                     .inflate(R.layout.item_profile_counter, parent, false),
                 editProfileCounterClickedListener
             )
+            else -> throw IllegalArgumentException("Unknown view type: $viewType")
         }
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        if (holder is EditProfileCounterViewHolder) {
-            //Offset by one for "Create" button
-            holder.bind(counters[position - 1])
+        when (val item = items[position]) {
+            is EditProfileItem.Name -> (holder as NameViewHolder).bind(item.name, item.isNameChangeEnabled)
+            is EditProfileItem.LifeCounter -> (holder as LifeCounterViewHolder).bind(item.lifeCounter)
+            is EditProfileItem.CountersHeader -> (holder as CountersHeaderViewHolder).bind()
+            is EditProfileItem.CreateCounter -> (holder as CreateCounterViewHolder).bind()
+            is EditProfileItem.Counter -> (holder as EditProfileCounterViewHolder).bind(item.counter)
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun getItemViewType(position: Int): Int {
+        return when (items[position]) {
+            is EditProfileItem.Name -> TYPE_NAME
+            is EditProfileItem.LifeCounter -> TYPE_LIFE_COUNTER
+            is EditProfileItem.CountersHeader -> TYPE_COUNTERS_HEADER
+            is EditProfileItem.CreateCounter -> TYPE_CREATE_COUNTER
+            is EditProfileItem.Counter -> TYPE_COUNTER
         }
     }
 
     override fun getItemId(position: Int): Long {
-        return if (position == 0) {
-            ID_CREATE
-        } else {
-            //Offset by one for "Create" button
-            return counters[position - 1].template.id.toLong()
+        return when (val item = items[position]) {
+            is EditProfileItem.Name -> "name".hashCode().toLong()
+            is EditProfileItem.LifeCounter -> "life_counter".hashCode().toLong()
+            is EditProfileItem.CountersHeader -> "counters_header".hashCode().toLong()
+            is EditProfileItem.CreateCounter -> "create_counter".hashCode().toLong()
+            is EditProfileItem.Counter -> item.counter.template.id.toLong()
         }
-    }
-
-    override fun getItemCount(): Int {
-        //add one for the "Create" button
-        return counters.size + 1
-    }
-
-    override fun getItemViewType(position: Int): Int {
-        return if (position == 0) TYPE_CREATE else TYPE_COUNTER
     }
 
     override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
@@ -88,6 +137,75 @@ class EditProfileRecyclerAdapter(
         if (holder is EditProfileCounterViewHolder) {
             holder.counterIconView.clearImage()
         }
+    }
+}
+
+sealed class EditProfileItem {
+    data class Name(val name: String, val isNameChangeEnabled: Boolean) : EditProfileItem()
+    data class LifeCounter(val lifeCounter: CounterTemplateModel?) : EditProfileItem()
+    data object CountersHeader : EditProfileItem()
+    data object CreateCounter : EditProfileItem()
+    data class Counter(val counter: CounterSelectionUiModel) : EditProfileItem()
+}
+
+class NameViewHolder(
+    itemView: View,
+    private val onNameChangedListener: (String) -> Unit
+) : RecyclerView.ViewHolder(itemView) {
+
+    private val nameEditText: EditText = itemView.findViewById(R.id.profile_name_edit_text)
+    private val textChangedListener = object : TextWatcher {
+        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+            onNameChangedListener(s.toString())
+        }
+        override fun afterTextChanged(s: Editable?) {}
+    }
+
+    init {
+        nameEditText.addTextChangedListener(textChangedListener)
+    }
+
+    fun bind(name: String, isNameChangeEnabled: Boolean) {
+        nameEditText.isEnabled = isNameChangeEnabled
+        nameEditText.isFocusable = isNameChangeEnabled
+        // Prevent updates while user is typing
+        if (!nameEditText.isFocused) {
+            nameEditText.removeTextChangedListener(textChangedListener)
+            nameEditText.setText(name)
+            nameEditText.addTextChangedListener(textChangedListener)
+        }
+    }
+}
+
+class LifeCounterViewHolder(
+    itemView: View,
+    private val onEditLifeCounterClickListener: () -> Unit
+) : RecyclerView.ViewHolder(itemView) {
+
+    private val lifeCounterView: LifeCounterView = itemView.findViewById(R.id.life_counter_preview_view)
+    private val editButton: ImageView = itemView.findViewById(R.id.edit_life_counter_button)
+
+    init {
+        editButton.setOnClickListener {
+            onEditLifeCounterClickListener()
+        }
+        if (ScThemeUtils.isLightTheme(itemView.context)) {
+            lifeCounterView.background = itemView.context.previewBackgroundColor.toDrawable()
+        }
+    }
+
+    fun bind(lifeCounter: CounterTemplateModel?) {
+        lifeCounterView.setCustomCounter(
+            counter = lifeCounter,
+            playerTint = itemView.context.previewBackgroundColor
+        )
+    }
+}
+
+class CountersHeaderViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    fun bind() {
+        // No binding needed for static text
     }
 }
 

--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -3,7 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="bottom"
     android:orientation="vertical"
     android:fitsSystemWindows="true">
 
@@ -11,102 +10,15 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        app:layout_constraintTop_toTopOf="parent"
         app:navigationIcon="@drawable/ic_back"
         app:title="@string/edit_profile_title" />
 
-
-    <ScrollView
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/profile_content_recycler"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:fillViewport="true">
-
-        <!-- TODO: wrapping this in a scrollview makes the recyclerview not actually
-         recycler, which is generally ok for this screen but not optimal -->
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/default_padding">
-
-            <TextView
-                android:id="@+id/profile_name_label"
-                style="@style/Header3"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/default_padding"
-                android:layout_marginBottom="@dimen/default_padding_half"
-                android:text="@string/profile_name_label"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <EditText
-                android:id="@+id/profile_name_edit_text"
-                style="@style/NameEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/default_padding"
-                android:imeOptions="actionDone"
-                app:layout_constraintTop_toBottomOf="@+id/profile_name_label" />
-
-            <TextView
-                android:id="@+id/life_counter_label"
-                style="@style/Header2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/edit_counter_horizontal_margin"
-                android:layout_marginTop="@dimen/edit_counter_section_spacing"
-                android:gravity="center"
-                android:text="@string/edit_profile_life"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/profile_name_edit_text" />
-
-            <ImageView
-                android:id="@+id/edit_life_counter_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:padding="8dp"
-                android:src="@drawable/ic_edit"
-                app:layout_constraintBottom_toBottomOf="@+id/life_counter_label"
-                app:layout_constraintStart_toEndOf="@+id/life_counter_label"
-                app:layout_constraintTop_toTopOf="@+id/life_counter_label"
-                app:tint="?attr/scTextColorPrimary" />
-
-
-            <com.kenkeremath.mtgcounter.view.counter.LifeCounterView
-                android:id="@+id/life_counter_preview_view"
-                android:layout_width="100dp"
-                android:layout_height="120dp"
-                android:layout_marginTop="@dimen/default_padding"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/life_counter_label" />
-
-            <TextView
-                android:id="@+id/counters_label"
-                style="@style/Header3"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/default_padding"
-                android:layout_marginTop="@dimen/default_padding"
-                android:text="@string/profile_edit_select_counters_header"
-                app:layout_constraintTop_toBottomOf="@+id/life_counter_preview_view" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/profile_counters_recycler"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/default_padding_half"
-                android:layout_weight="1"
-                android:nestedScrollingEnabled="false"
-                android:overScrollMode="never"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/counters_label" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </ScrollView>
+        android:overScrollMode="never" />
 
     <Button
         android:id="@+id/save"
@@ -114,6 +26,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/menu_button_margin"
-        android:text="@string/save"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        android:text="@string/save" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/item_edit_profile_counters_header.xml
+++ b/app/src/main/res/layout/item_edit_profile_counters_header.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Header3"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/default_padding"
+    android:layout_marginTop="@dimen/default_padding"
+    android:text="@string/profile_edit_select_counters_header" /> 

--- a/app/src/main/res/layout/item_edit_profile_life_counter.xml
+++ b/app/src/main/res/layout/item_edit_profile_life_counter.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    android:padding="@dimen/default_padding">
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_gravity="center_horizontal"
+        android:gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <TextView
+            style="@style/Header2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginHorizontal="@dimen/edit_counter_horizontal_margin"
+            android:text="@string/edit_profile_life" />
+
+        <ImageView
+            android:id="@+id/edit_life_counter_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_gravity="center_vertical"
+            android:padding="8dp"
+            android:src="@drawable/ic_edit"
+            app:tint="?attr/scTextColorPrimary" />
+
+    </LinearLayout>
+
+    <com.kenkeremath.mtgcounter.view.counter.LifeCounterView
+        android:id="@+id/life_counter_preview_view"
+        android:layout_width="100dp"
+        android:layout_height="120dp"
+        android:layout_marginTop="@dimen/default_padding"
+        android:layout_gravity="center"/>
+
+</LinearLayout> 

--- a/app/src/main/res/layout/item_edit_profile_name.xml
+++ b/app/src/main/res/layout/item_edit_profile_name.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="@dimen/default_padding">
+
+    <TextView
+        style="@style/Header3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/default_padding_half"
+        android:text="@string/profile_name_label" />
+
+    <EditText
+        android:id="@+id/profile_name_edit_text"
+        style="@style/NameEditText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:imeOptions="actionDone" />
+
+</LinearLayout> 


### PR DESCRIPTION
Add all scrollable items to recyclerview in `EditProfileDialogFragment` and remove ScrollView. This allows content to scroll and measure correctly

| Before | After | 
| ----- | ----- |
| ![screenrecord_2025-07-02_14-04-47](https://github.com/user-attachments/assets/9f6c8bd3-c222-4321-9bf8-4f9aee4cb748) |  ![screenrecord_2025-07-02_14-03-19](https://github.com/user-attachments/assets/565ba155-80f4-4018-afd1-4aad4e499878) |

